### PR TITLE
GDB-6815: Resource view on mobile

### DIFF
--- a/src/boolean.js
+++ b/src/boolean.js
@@ -16,7 +16,15 @@ var root = module.exports = function(yasr) {
     yasr.translate = require('./translate.js')(yasr.options.locale);
 
 	var container = $("<div class='booleanResult'></div>");
-	var draw = function() {
+	var plugin = {
+		id: 'boolean',
+		name: null,//don't need to set this: we don't show it in the selection widget anyway, so don't need a human-friendly name
+		hideFromSelection: true,
+		getPriority: 1,
+	}
+	plugin.options = $.extend(true, {}, yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {});
+
+	plugin.draw = function() {
 		container.empty().appendTo(yasr.resultsContainer);
 		var booleanVal = yasr.results.getBoolean();
 		
@@ -38,21 +46,11 @@ var root = module.exports = function(yasr) {
 		
 		$("<span></span>").text(textVal).appendTo(container);
 	};
-	
 
-	var canHandleResults = function(){return yasr.results.getBoolean && (yasr.results.getBoolean() === true || yasr.results.getBoolean() == false);};
+	plugin.canHandleResults = function(){return yasr.results.getBoolean && (yasr.results.getBoolean() === true || yasr.results.getBoolean() == false);};
 
-	
-	
-	return {
-		name: null,//don't need to set this: we don't show it in the selection widget anyway, so don't need a human-friendly name
-		draw: draw,
-		hideFromSelection: true,
-		getPriority: 1,
-		canHandleResults: canHandleResults
-	}
+	return plugin;
 };
-
 
 root.version = {
 	"YASR-boolean" : require("../package.json").version,

--- a/src/booleanBootstrap.js
+++ b/src/booleanBootstrap.js
@@ -16,7 +16,15 @@ var root = module.exports = function(yasr) {
     yasr.translate = require('./translate.js')(yasr.options.locale);
 
 	var container = $("<div class='booleanBootResult'></div>");
-	var draw = function() {
+	const plugin = {
+		id: 'booleanBootstrap',
+		name: null,//don't need to set this: we don't show it in the selection widget anyway, so don't need a human-friendly name
+		hideFromSelection: true,
+		getPriority: 3,
+	}
+	plugin.options = $.extend(true, {}, yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {});
+
+	plugin.draw = function() {
 		container.empty().appendTo(yasr.resultsContainer);
 		var booleanVal = yasr.results.getBoolean();
 		
@@ -32,21 +40,11 @@ var root = module.exports = function(yasr) {
 			
 		alert.appendTo(container);
 	};
-	
 
-	var canHandleResults = function(){return yasr.results.getBoolean && (yasr.results.getBoolean() === true || yasr.results.getBoolean() == false);};
+	plugin.canHandleResults = function(){return yasr.results.getBoolean && (yasr.results.getBoolean() === true || yasr.results.getBoolean() == false);};
 
-	
-	
-	return {
-		name: null,//don't need to set this: we don't show it in the selection widget anyway, so don't need a human-friendly name
-		draw: draw,
-		hideFromSelection: true,
-		getPriority: 3,
-		canHandleResults: canHandleResults
-	}
+	return plugin;
 };
-
 
 root.version = {
 	"YASR-boolean" : require("../package.json").version,

--- a/src/error.js
+++ b/src/error.js
@@ -16,8 +16,17 @@ var root = module.exports = function(yasr) {
     yasr.translate = require('./translate.js')(yasr.options.locale);
 
 	var $container = $("<div class='errorResult'></div>");
-	var options = $.extend(true, {}, root.defaults);
-	
+
+	const plugin = {
+		id: 'error',
+		name: null,//don't need to set this: we don't show it in the selection widget anyway, so don't need a human-friendly name
+		getPriority: 20,
+		hideFromSelection: true,
+	}
+
+	const customOptions = yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {};
+	var options = plugin.options = $.extend(true, {}, root.defaults, customOptions);
+
 	var getTryBtn = function(){
 		var $tryBtn = null;
 		if (options.tryQueryLink) {
@@ -32,7 +41,7 @@ var root = module.exports = function(yasr) {
 		return $tryBtn;
 	}
 	
-	var draw = function() {
+	plugin.draw = function() {
 		var error = yasr.results.getException();
 		$container.empty().appendTo(yasr.resultsContainer);
 		var $header = $("<div>", {class:'errorHeader'}).appendTo($container);
@@ -71,17 +80,9 @@ var root = module.exports = function(yasr) {
 		}
 		
 	};
-	
-	
-	var  canHandleResults = function(yasr){return yasr.results.getException() || false;};
-	
-	return {
-		name: null,//don't need to set this: we don't show it in the selection widget anyway, so don't need a human-friendly name
-		draw: draw,
-		getPriority: 20,
-		hideFromSelection: true,
-		canHandleResults: canHandleResults,
-	}
+
+	plugin.canHandleResults = function(yasr){return yasr.results.getException() || false;};
+	return plugin;
 };
 
 /**

--- a/src/graph.js
+++ b/src/graph.js
@@ -12,6 +12,15 @@ var root = module.exports = function(yasr) {
 		graphJson: require("./parsers/graphJson.js"),
 	};
 
+	const plugin = {
+		id: 'graphBeta',
+		name: 'Graph(beta)',
+		nameLabel: 'yasr.graph.beta',
+		getPriority: 20,
+		hideFromSelection: false,
+	}
+	plugin.options = $.extend(true, {}, yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {});
+
 	var invertedPrefixes = function() {
 		if (yasr.options.getUsedPrefixes) {
 			return _.invert(typeof yasr.options.getUsedPrefixes == "function"? yasr.options.getUsedPrefixes(yasr):  yasr.options.getUsedPrefixes);
@@ -120,7 +129,7 @@ var root = module.exports = function(yasr) {
 	}
 
 
-	var draw = function() {
+	plugin.draw = function() {
 		yasr.resultsContainer.empty();
 		yasr.resultsContainer.append('<div class="graph-info-title"></div><div class="graph-info"></div><div id="cy"></div>');
 		
@@ -206,16 +215,9 @@ var root = module.exports = function(yasr) {
 		});
 	}
 
-	var canHandleResults = function() {
+	plugin.canHandleResults = function() {
 		return "CONSTRUCT" == window.editor.getQueryType() || "DESCRIBE" == window.editor.getQueryType();
 	}
 
-	return {
-		name: 'Graph(beta)',
-		nameLabel: 'yasr.graph.beta',
-		draw: draw,
-		getPriority: 20,
-		hideFromSelection: false,
-		canHandleResults: canHandleResults,
-	}
+	return plugin;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,6 @@ console = console || {"log":function(){}};//make sure any console statements don
 
 require('./jquery/extendJquery.js');
 
-
-
 /**
  * Main YASR constructor
  * 
@@ -17,8 +15,6 @@ require('./jquery/extendJquery.js');
  * @return {doc} YASR document
  */
 var root = module.exports = function(parent, options, queryResults) {
-
-
 	var yasr = {};
 	yasr.options = $.extend(true, {}, root.defaults, options);
 	yasr.container = $(parent).find(".yasr");
@@ -476,6 +472,18 @@ var root = module.exports = function(parent, options, queryResults) {
 		yasr.setResponse(queryResults);
 	} 
 	yasr.updateHeader();
+
+	const resizeEvent = 'resize.' + new Date().getTime();
+	$(window).on(resizeEvent, yasr.draw);
+
+	yasr.destroy = function () {
+		$(window).off(resizeEvent);
+		for (const plugin in yasr.plugins) {
+			if ($.isFunction(plugin.destroy)) {
+				plugin.destroy();
+			}
+		}
+	}
 	return yasr;
 };
 

--- a/src/pivot.js
+++ b/src/pivot.js
@@ -11,9 +11,16 @@ var root = module.exports = function(yasr) {
     // load and register the translation service providing the locale config
     yasr.translate = require('./translate.js')(yasr.options.locale);
 
-	var plugin = {};
-	var options = $.extend(true, {}, root.defaults);
-	
+	var plugin = {
+		id: 'pivot',
+		name: "Pivot Table",
+		nameLabel: 'yasr.pivot.pivot_table',
+		getPriority: 4,
+	};
+
+	const customOptions = yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {};
+	var options = plugin.options = $.extend(true, {}, root.defaults, customOptions);
+
 	if (options.useD3Chart) {
 		try {
 			// Don't load d3 here, use the global one
@@ -24,9 +31,7 @@ var root = module.exports = function(yasr) {
 		}
 		if ($.pivotUtilities.d3_renderers) $.extend(true,  $.pivotUtilities.renderers, $.pivotUtilities.d3_renderers);
 	}
-	
-	
-	
+
 	var $pivotWrapper;
 	var mergeLabelPostfix = null;
 	var getShownVariables = function() {
@@ -49,7 +54,6 @@ var root = module.exports = function(yasr) {
 	};
 	
 	var formatForPivot = function(callback) {
-		
 		var vars = getShownVariables();
 		var usedPrefixes = null;
 		if (yasr.options.getUsedPrefixes) {
@@ -100,7 +104,8 @@ var root = module.exports = function(yasr) {
 		}
 		return settings;
 	};
-	var draw = function() {
+
+	plugin.draw = function() {
 		var doDraw = function() {
 			var onRefresh = function(pivotObj) {
 				if (persistencyId) {
@@ -182,11 +187,12 @@ var root = module.exports = function(yasr) {
 			doDraw();
 		}
 	};
-	var canHandleResults = function(){
+
+	plugin.canHandleResults = function(){
 		return yasr.results && yasr.results.getVariables && yasr.results.getVariables() && yasr.results.getVariables().length > 0;
 	};
 	
-	var getDownloadInfo =  function() {
+	plugin.getDownloadInfo =  function() {
 		if (!yasr.results) return null;
 		var svgEl = yasr.resultsContainer.find('.pvtRendererArea svg');
 		if (svgEl.length > 0) {
@@ -221,7 +227,8 @@ var root = module.exports = function(yasr) {
 		} 
 		
 	};
-	var getEmbedHtml = function() {
+
+	plugin.getEmbedHtml = function() {
 		if (!yasr.results) return null;
 		
 		var svgEl = yasr.resultsContainer.find('.pvtRendererArea svg')
@@ -238,19 +245,9 @@ var root = module.exports = function(yasr) {
 		//don't use jquery, so we can easily influence indentation
 		return '<div style="width: 800px; height: 600px;">\n' + htmlString + '\n</div>';
 	};
-	return {
-		getDownloadInfo: getDownloadInfo,
-		getEmbedHtml: getEmbedHtml,
-		options: options,
-		draw: draw,
-		name: "Pivot Table",
-		nameLabel: 'yasr.pivot.pivot_table',
-		canHandleResults: canHandleResults,
-		getPriority: 4,
-	}
+
+	return plugin;
 };
-
-
 
 root.defaults = {
 	mergeLabelsWithUris: false,

--- a/src/rawResponse.js
+++ b/src/rawResponse.js
@@ -15,10 +15,18 @@ var root = module.exports = function(yasr) {
     // load and register the translation service providing the locale config
     yasr.translate = require('./translate.js')(yasr.options.locale);
 
-	var plugin = {};
-	var options = $.extend(true, {}, root.defaults);
+	const plugin = {
+		id: 'rawResponse',
+		name: "Raw Response",
+		nameLabel: 'yasr.name.raw_response',
+		getPriority: 2,
+	}
+
+	const customOptions = yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {};
+	var options = plugin.options = $.extend(true, {}, root.defaults, customOptions);
 	var cm = null;
-	var draw = function() {
+
+	plugin.draw = function() {
 		var cmOptions = options.CodeMirror;
 		cmOptions.value = yasr.results.getShortOriginalResponse(options.limit);
 		
@@ -40,17 +48,17 @@ var root = module.exports = function(yasr) {
 		cm.on('unfold', function() {
 			cm.refresh();
 		});
-		
 	};
-	var canHandleResults = function(){
+
+	plugin.canHandleResults = function(){
 		if (!yasr.results) return false;
 		if (!yasr.results.getOriginalResponseAsString) return false;
 		var response = yasr.results.getOriginalResponseAsString();
 		if ((!response || response.length === 0) && yasr.results.getException()) return false;//in this case, show exception instead, as we have nothing to show anyway
 		return true;
 	};
-	
-	var getDownloadInfo = function() {
+
+	plugin.getDownloadInfo = function() {
 		if (!yasr.results) return null;
 		var contentType = yasr.results.getOriginalContentType();
 		var type = yasr.results.getType();
@@ -62,18 +70,8 @@ var root = module.exports = function(yasr) {
 		};
 	};
 	
-	return {
-		draw: draw,
-		name: "Raw Response",
-		nameLabel: 'yasr.name.raw_response',
-		canHandleResults: canHandleResults,
-		getPriority: 2,
-		getDownloadInfo: getDownloadInfo,
-		
-	}
+	return plugin;
 };
-
-
 
 root.defaults = {
 	CodeMirror: {

--- a/src/table.js
+++ b/src/table.js
@@ -25,11 +25,14 @@ var root = module.exports = function(yasr) {
 
 	var table = null;
 	var plugin = {
+		id: 'table',
 		name: "Table",
 		nameLabel: 'yasr.table',
 		getPriority: 10,
 	};
-	var options = plugin.options = $.extend(true, {}, root.defaults);
+
+	const customOptions = yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {};
+	var options = plugin.options = $.extend(true, {}, root.defaults, customOptions);
 	var tableLengthPersistencyId = (options.persistency? yasr.getPersistencyId(options.persistency.tableLength): null);
 
 	var getRows = function() {
@@ -133,7 +136,7 @@ var root = module.exports = function(yasr) {
 		// hideOrShowDatatablesControls();
 		addAdditionalEvents();
 	};
-	
+
 	plugin.draw = function() {
 		table = $('<table cellpadding="0" cellspacing="0" border="0" class="resultsTable table stripe hover table-bordered fixedCellWidth"></table>');
 		$(yasr.resultsContainer).html(table);
@@ -152,11 +155,12 @@ var root = module.exports = function(yasr) {
 		
 		
 		drawSvgIcons();
-		
-		addEvents();
-		
-		//finally, make the columns dragable:
-		table.colResizable();
+
+		if (!options.enableColumnResizingOnWindowWidth || options.enableColumnResizingOnWindowWidth <= $(window).width()) {
+			addEvents();
+			//finally, make the columns dragable:
+			table.colResizable();
+		}
 		//and: make sure the height of the resize handlers matches the height of the table header
 		var thHeight = table.find('thead').outerHeight();
 		$(yasr.resultsContainer).find('.JCLRgrip').height(table.find('thead').outerHeight());


### PR DESCRIPTION
What?
 There was wrong calculation of table size when page is loaded on mobile.

Why?
 "colResizable-1.4.js" library is used for column size calculation. It don't do its job properly on mobile.

How?

 - Added functionality to switch off column resizing when screen width is small.
 - Extended yasr constructor with possibility to pass options to concrete plugin.
 - Added event listener for window resize event. When the event occurred table will be redrawn.
 - Added destroy function which remove the listeners and call destroy function of each plugin. This function have to be called everywhere where an instance of yasr is destroyed.