### PR TITLE
GDB-8100: UI language switch does not take effect immediately

### DIFF
--- a/src/boolean.js
+++ b/src/boolean.js
@@ -13,7 +13,7 @@ var $ = require("jquery");
  */
 var root = module.exports = function(yasr) {
     // load and register the translation service providing the locale config
-    yasr.translate = require('./translate.js')(yasr.options.locale);
+    yasr.translate = require('./translate.js').translate;
 
 	var container = $("<div class='booleanResult'></div>");
 	var plugin = {

--- a/src/booleanBootstrap.js
+++ b/src/booleanBootstrap.js
@@ -13,7 +13,7 @@ var $ = require("jquery");
  */
 var root = module.exports = function(yasr) {
     // load and register the translation service providing the locale config
-    yasr.translate = require('./translate.js')(yasr.options.locale);
+    yasr.translate = require('./translate.js').translate;
 
 	var container = $("<div class='booleanBootResult'></div>");
 	const plugin = {

--- a/src/error.js
+++ b/src/error.js
@@ -13,7 +13,7 @@ var $ = require("jquery");
  */
 var root = module.exports = function(yasr) {
     // load and register the translation service providing the locale config
-    yasr.translate = require('./translate.js')(yasr.options.locale);
+    yasr.translate = require('./translate.js').translate;
 
 	var $container = $("<div class='errorResult'></div>");
 

--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -1,6 +1,6 @@
 module.exports = {
 	GoogleTypeException: function (foundTypes, varName) {
-		let translate = require('./translate.js')('');
+		let translate = require('./translate.js').translate;
 		this.foundTypes = foundTypes;
 		this.varName = varName;
 		this.toString = function () {

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -1,5 +1,5 @@
 'use strict';
-let translate = require('./translate.js')();
+let translate = require('./translate.js').translate;
 let download = translate('yasr.download.as.label');
 module.exports = {
     selectSaveAsDropDown: '<div class="saveAsDropDown btn-group pull-right">' + 

--- a/src/gChartLoader.js
+++ b/src/gChartLoader.js
@@ -5,7 +5,7 @@ var loadingMain = false;
 var loadingFailed = false;
 var loader = function() {
     // load and register the translation service providing the locale config
-	let translate = require('./translate.js')('');
+	let translate = require('./translate.js').translate;
 
 	EventEmitter.call(this);
 	var mod = this;

--- a/src/gchart.js
+++ b/src/gchart.js
@@ -9,7 +9,7 @@ var $ = require('jquery'),
 
 var root = module.exports = function(yasr){
     // load and register the translation service providing the locale config
-    yasr.translate = require('./translate.js')(yasr.options.locale);
+    yasr.translate = require('./translate.js').translate;
 
 	var options = $.extend(true, {}, root.defaults);
 	var id = yasr.container.closest('[id]').attr('id');

--- a/src/main.js
+++ b/src/main.js
@@ -23,10 +23,12 @@ var root = module.exports = function(parent, options, queryResults) {
 	yasr.storage = utils.storage;
 
     // load and register the translation service providing the locale config
-    yasr.translate = require('./translate.js')(yasr.options.locale);
+	yasr.translationService = require('./translate.js');
+	yasr.translationService.setLanguage(yasr.options.locale);
+    yasr.translate = yasr.translationService.translate;
 
 	yasr.changeLanguage = function (lang) {
-		yasr.translate = require('./translate.js')(lang);
+		yasr.translationService.setLanguage(lang);
 		let downLoadBtn = document.getElementById('saveAsBtn');
 		if (downLoadBtn) {
 			downLoadBtn.innerText = yasr.translate('yasr.download.as.label');

--- a/src/pivot.js
+++ b/src/pivot.js
@@ -9,7 +9,7 @@ require('pivottable');
 if (!$.fn.pivotUI) throw new Error("Pivot lib not loaded");
 var root = module.exports = function(yasr) {
     // load and register the translation service providing the locale config
-    yasr.translate = require('./translate.js')(yasr.options.locale);
+    yasr.translate = require('./translate.js').translate;
 
 	var plugin = {
 		id: 'pivot',

--- a/src/rawResponse.js
+++ b/src/rawResponse.js
@@ -13,7 +13,7 @@ require('codemirror/mode/javascript/javascript.js');
 
 var root = module.exports = function(yasr) {
     // load and register the translation service providing the locale config
-    yasr.translate = require('./translate.js')(yasr.options.locale);
+    yasr.translate = require('./translate.js').translate;
 
 	const plugin = {
 		id: 'rawResponse',

--- a/src/table.js
+++ b/src/table.js
@@ -21,7 +21,7 @@ require("../lib/colResizable-1.4.js");
  */
 var root = module.exports = function(yasr) {
     // load and register the translation service providing the locale config
-    yasr.translate = require('./translate.js')(yasr.options.locale);
+    yasr.translate = require('./translate.js').translate;
 
 	var table = null;
 	var plugin = {
@@ -149,7 +149,7 @@ var root = module.exports = function(yasr) {
 		var pLength = yutils.storage.get(tableLengthPersistencyId);
 		if (pLength) dataTableConfig.pageLength = pLength;
 
-		dataTableConfig.translate = require('./translate.js')(yasr.options.locale);
+		dataTableConfig.translate = require('./translate.js').translate;
 
 		table.DataTable($.extend(true, {}, dataTableConfig));//make copy. datatables adds properties for backwards compatability reasons, and don't want this cluttering our own
 

--- a/src/translate.js
+++ b/src/translate.js
@@ -27,11 +27,11 @@ var translate = function (key, parameter) {
     return key;
 };
 
-function init(lang) {
-    if (lang) {
-        currentLang = lang;
-    }
-    return translate;
+function setLanguage(lang) {
+    currentLang = lang;
 }
 
-module.exports = init;
+module.exports = {
+    setLanguage,
+    translate
+}


### PR DESCRIPTION
## What
When user changes the language the label of download dropdown is changed as expected, but when execute a query label is on wrong language.

## Why
- "Download As" dropdown html (as string) is defined in separate module "extensions.js". Inside the module there is translation of dropdown label, but it uses the default language when page is loaded. This module is used when dropdown is created after every execution of query.
- When user changes the language there is code which find dropdown and change it label according selected language and that's why label is correct.
- When user run a query results and the dropdown are recreated. Recreation of "Download As" use the external module described above and label is translate on language when the page is loaded.

## How
Refactored translation module to hold state of currently selected language and use it when translate method is called.