### PR TITLE
GDB-8129: Long IRIs are cut from the SPARQL results view

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -252,7 +252,12 @@ var root = module.exports = function(yasr) {
 };
 
 var addWorldBreakTagAfterSpecialCharacters = function (text) {
-	return text.replace(/([_:/-](?![_:/-]))/g, "$1<wbr>");
+	// Add wbr tag after "_" or ":" only if they are not followed by "_", ":" or "-".
+	return text.replace(/([_:](?![_:/-]))/g, "$1<wbr>")
+		// Add wbr tag after "/" only if it is not preceded by "<" and not followed by "/", "_", ":" or "-"
+		.replace(/((?<!<)[/](?![_:/-]))/g, "$1<wbr>")
+		// Add wbr tag after "-" only if it is not preceded by "@" followed by characters regardless of the language and not followed by "/", "_", ":" or "-"
+		.replace(/((?<!@\p{L}*)[-](?![_:/-]))/gu, "$1<wbr>");
 };
 
 var addWorldBreakTagBeforeSpecialCharacters = function (text) {


### PR DESCRIPTION
GDB-8129: Long IRIs are cut from the SPARQL results view

## What
When you run a query that returns a result with a language tag, the display of the result is wrong. For example:
  - if some literal has an "en" tag, then "@ensup>" will be displayed;
  - if some literal has an "en-GB" tag, then the html of the literal is "@en-<wbr>GBsup>";

## Why
 Before displaying the results, we insert a <wbr> after special characters (_:/-) to ensure that the result will not be an overflow cell element. The problem occurred because the literals that has language tag contains "/" (an of the special characters which we process). As result the html of the processing literal is "<sup>@en/<wbr>sup>".

## How
- The "/" character is handled separately from the others. The wbr tag is added only if "/" is not preceded by "<" and is not followed by "/", "_", ":" or "-";
- The "-" character is handled separately from the others. The wbr tag is added only if "-" is not preceded by "@" followed by characters regardless of the language and not followed by "/", "_", ":" or "-"