### PR TITLE
GDB-8129: Removes wbr tag from cells displayed bnode type result

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -403,7 +403,7 @@ var formatLiteralCustom = function(yasr, literalBinding, forHtml) {
 	var stringRepresentation = utils.escapeHtmlEntities(literalBinding.value);
 	var xmlSchemaNs = "http://www.w3.org/2001/XMLSchema#";
 	if ("bnode" === literalBinding.type) {
-		return addWordBreakToLiterals("_:" + stringRepresentation);
+		return "_:" + stringRepresentation;
 	} else if (literalBinding["xml:lang"]) {
 		stringRepresentation = '"' + stringRepresentation + ((forHtml) ? '"<sup>': '"') + '@' + literalBinding["xml:lang"] + ((forHtml) ? '</sup>': '');
 	} else if (literalBinding["lang"]) {


### PR DESCRIPTION
## What
If a cell of sparql results table displays value of type bnode, the bnode value is on next line than the prefix "_:".

## Why
 The functionality that process formatting of bnode adds this unwanted tag.

## How
Removes adding of wbr tag bnode formatting functionality.