### PR TITLE
GDB-9306 - Add missing renderers in pivot chart

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -87,7 +87,8 @@ function getGraphSaveAsDropDown() {
                         '<a class="format dropdown-item" data-accepts="application/x-trigstar" href="#">TriG*</a>' +
                     '</li>' +
                     '<li>' +
-                        '<a class="format dropdown-item" data-accepts="application/x-binary-rdf" href="#">Binary RDF</a>' +
+                        '<a class="format dropdown-item" data-accepts="application/x-binary-rdf" href="#">' +
+                            getDropdownItemLabel('yasr.download.rdf.label') + '</a>' +
                     '</li>' +
                 '</ul>' +
             '</div>'

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -29,6 +29,7 @@
   "yasr.btn.label.save": "Get HTML snippet to embed results on a web page",
   "yasr.download.as.label": "Download as",
   "yasr.download.as.rdf.label": "Binary RDF Results",
+  "yasr.download.rdf.label": "Binary RDF",
   "yasr.btn.title.svg": "Download SVG Image",
   "yasr.btn.title.csv": "Download as CSV",
   "yasr.btn.title.raw": "Download raw response",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -29,6 +29,7 @@
   "yasr.btn.label.save": "Obtenir un extrait HTML pour intégrer les résultats dans une page web",
   "yasr.download.as.label": "Téléchargement",
   "yasr.download.as.rdf.label": "Résultats en RDF binaire",
+  "yasr.download.rdf.label": "RDF binaire",
   "yasr.btn.title.svg": "Télécharger l'image SVG",
   "yasr.btn.title.csv": "Télécharger comme CSV",
   "yasr.btn.title.raw": "Télécharger la réponse brute",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -28,7 +28,7 @@
   "yasr.btn.title.embed": "Sauvegarder",
   "yasr.btn.label.save": "Obtenir un extrait HTML pour intégrer les résultats dans une page web",
   "yasr.download.as.label": "Téléchargement",
-  "yasr.download.as.rdf.label": "Résultats en RDF binaire",
+  "yasr.download.as.rdf.label": "RDF binaire",
   "yasr.download.rdf.label": "RDF binaire",
   "yasr.btn.title.svg": "Télécharger l'image SVG",
   "yasr.btn.title.csv": "Télécharger comme CSV",

--- a/src/pivot.fr.js
+++ b/src/pivot.fr.js
@@ -63,18 +63,7 @@
                 "Compte comme fraction de lignes": tpl.fractionOf(tpl.count(), "row", frFmtPct),
                 "Compte comme fraction de colonnes": tpl.fractionOf(tpl.count(), "col", frFmtPct)
             },
-            renderers: {
-                "Tableau": $.pivotUtilities.renderers["Table"],
-                "Tableau &agrave; barres": $.pivotUtilities.renderers["Table Barchart"],
-                "Carte de chaleur": $.pivotUtilities.renderers["Heatmap"],
-                "Carte de chaleur par ligne": $.pivotUtilities.renderers["Row Heatmap"],
-                "Carte de chaleur par colonne": $.pivotUtilities.renderers["Col Heatmap"],
-                "Graphique lin&eacute;aire": $.pivotUtilities.renderers["Line Chart"],
-                "Graphique &agrave; barres": $.pivotUtilities.renderers["Bar Chart"],
-                "Graphique &agrave; barres empil&eacute;es": $.pivotUtilities.renderers["Stacked Bar Chart"],
-                "Graphique en aires": $.pivotUtilities.renderers["Area Chart"],
-                "Nuage de points": $.pivotUtilities.renderers["Scatter Chart"]
-            }
+            renderers: {}
         };
     });
 

--- a/src/pivot.fr.js
+++ b/src/pivot.fr.js
@@ -45,30 +45,35 @@
                 by: "par"
             },
             aggregators: {
-                "Nombre": tpl.count(frFmtInt),
-                "Nombre de valeurs uniques": tpl.countUnique(frFmtInt),
-                "Liste de valeurs uniques": tpl.listUnique(", "),
+                "Compte": tpl.count(frFmtInt),
+                "Compte des valeurs uniques": tpl.countUnique(frFmtInt),
+                "Liste des valeurs uniques": tpl.listUnique(", "),
                 "Somme": tpl.sum(frFmt),
-                "Somme en entiers": tpl.sum(frFmtInt),
+                "Somme des entiers": tpl.sum(frFmtInt),
                 "Moyenne": tpl.average(frFmt),
                 "Minimum": tpl.min(frFmt),
                 "Maximum": tpl.max(frFmt),
                 "Ratio de sommes": tpl.sumOverSum(frFmt),
-                "Borne sup&eacute;rieure 80%": tpl.sumOverSumBound80(true, frFmt),
-                "Borne inf&eacute;rieure 80%": tpl.sumOverSumBound80(false, frFmt),
-                "Somme en proportion du totale": tpl.fractionOf(tpl.sum(), "total", frFmtPct),
-                "Somme en proportion de la ligne": tpl.fractionOf(tpl.sum(), "row", frFmtPct),
-                "Somme en proportion de la colonne": tpl.fractionOf(tpl.sum(), "col", frFmtPct),
-                "Nombre en proportion du totale": tpl.fractionOf(tpl.count(), "total", frFmtPct),
-                "Nombre en proportion de la ligne": tpl.fractionOf(tpl.count(), "row", frFmtPct),
-                "Nombre en proportion de la colonne": tpl.fractionOf(tpl.count(), "col", frFmtPct)
+                "Limite sup&eacute;rieure 80%": tpl.sumOverSumBound80(true, frFmt),
+                "Limite inf&eacute;rieure 80%": tpl.sumOverSumBound80(false, frFmt),
+                "Somme comme fraction du total": tpl.fractionOf(tpl.sum(), "total", frFmtPct),
+                "Somme comme fraction de lignes": tpl.fractionOf(tpl.sum(), "row", frFmtPct),
+                "Somme comme fraction de colonnes": tpl.fractionOf(tpl.sum(), "col", frFmtPct),
+                "Compte comme fraction du total": tpl.fractionOf(tpl.count(), "total", frFmtPct),
+                "Compte comme fraction de lignes": tpl.fractionOf(tpl.count(), "row", frFmtPct),
+                "Compte comme fraction de colonnes": tpl.fractionOf(tpl.count(), "col", frFmtPct)
             },
             renderers: {
                 "Tableau": $.pivotUtilities.renderers["Table"],
-                "Table avec barres": $.pivotUtilities.renderers["Table Barchart"],
+                "Tableau &agrave; barres": $.pivotUtilities.renderers["Table Barchart"],
                 "Carte de chaleur": $.pivotUtilities.renderers["Heatmap"],
                 "Carte de chaleur par ligne": $.pivotUtilities.renderers["Row Heatmap"],
-                "Carte de chaleur par colonne": $.pivotUtilities.renderers["Col Heatmap"]
+                "Carte de chaleur par colonne": $.pivotUtilities.renderers["Col Heatmap"],
+                "Graphique lin&eacute;aire": $.pivotUtilities.renderers["Line Chart"],
+                "Graphique &agrave; barres": $.pivotUtilities.renderers["Bar Chart"],
+                "Graphique &agrave; barres empil&eacute;es": $.pivotUtilities.renderers["Stacked Bar Chart"],
+                "Graphique en aires": $.pivotUtilities.renderers["Area Chart"],
+                "Nuage de points": $.pivotUtilities.renderers["Scatter Chart"]
             }
         };
     });

--- a/src/pivot.js
+++ b/src/pivot.js
@@ -5,12 +5,12 @@ var $ = require("jquery"),
 	imgs = require('./imgs.js');
 require('jquery-ui/sortable');
 require('pivottable');
+require("./pivot.fr");
 
 if (!$.fn.pivotUI) throw new Error("Pivot lib not loaded");
 var root = module.exports = function(yasr) {
     // load and register the translation service providing the locale config
     yasr.translateService = require('./translate.js');
-	$.pivotUtilities.locales = require('./pivot.fr.js');
 
 	var plugin = {
 		id: 'pivot',
@@ -144,6 +144,19 @@ var root = module.exports = function(yasr) {
 			    	if (originalRefresh) originalRefresh(pivotObj);
 			    };
 			})();
+			$.pivotUtilities.locales.fr.renderers =
+				{
+					"Tableau": $.pivotUtilities.renderers["Table"],
+					"Tableau &agrave; barres": $.pivotUtilities.renderers["Table Barchart"],
+					"Carte de chaleur": $.pivotUtilities.renderers["Heatmap"],
+					"Carte de chaleur par ligne": $.pivotUtilities.renderers["Row Heatmap"],
+					"Carte de chaleur par colonne": $.pivotUtilities.renderers["Col Heatmap"],
+					"Graphique lin&eacute;aire": $.pivotUtilities.renderers["Line Chart"],
+					"Graphique &agrave; barres": $.pivotUtilities.renderers["Bar Chart"],
+					"Graphique &agrave; barres empil&eacute;es": $.pivotUtilities.renderers["Stacked Bar Chart"],
+					"Graphique en aires": $.pivotUtilities.renderers["Area Chart"],
+					"Nuage de points": $.pivotUtilities.renderers["Scatter Chart"]
+				}
 
 			window.pivot = $pivotWrapper.pivotUI(formatForPivot, settings, false, yasr.translateService.getLanguage());
 

--- a/src/pivot.js
+++ b/src/pivot.js
@@ -20,6 +20,10 @@ var root = module.exports = function(yasr) {
 	};
 
 	const customOptions = yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {};
+	// All renderer names for Google charts in every language are added here
+	const gchartRendererNames = ["line chart", "bar chart", "stacked bar chart", "area chart", "scatter chart",
+		"graphique lin&eacute;aire", "graphique &agrave; barres", "graphique &agrave; barres empil&eacute;es", "graphique en aires", "nuage de points"]
+
 	var options = plugin.options = $.extend(true, {}, root.defaults, customOptions);
 
 	if (options.useD3Chart) {
@@ -119,7 +123,8 @@ var root = module.exports = function(yasr) {
 					}
 					yUtils.storage.set(persistencyId, storeSettings, "month");
 				}
-				if (pivotObj.rendererName.toLowerCase().indexOf(' chart') >= 0) {
+
+				if (gchartRendererNames.indexOf(pivotObj.rendererName.toLowerCase()) >= 0) {
 					openGchartBtn.show();
 				} else {
 					openGchartBtn.hide();


### PR DESCRIPTION
## What?
The French and English Pivot chart renderers list contain the same charts. Missing French translations have been added. The chart config button in the Pivot chart will appear when required.

## Why?
The requirements were missed.

## How?
I manually added the renderers in French and added the missing labels. I corrected the logic for the chart config button. 